### PR TITLE
Force managed host projects to be AnyCpu

### DIFF
--- a/appveyor.cmd
+++ b/appveyor.cmd
@@ -10,7 +10,7 @@ msbuild -p:Configuration=%_C% src\test\examples\examples.proj || exit /b
 dotnet test -c %_C% --no-build src\test\WixToolsetTest.Bal || exit /b
 dotnet test -c %_C% --no-build src\test\WixToolsetTest.ManagedHost || exit /b
 
-msbuild -p:Configuration=%_C% -t:Pack src\wixext\WixToolset.Bal.wixext.csproj || exit /b
+msbuild -p:Configuration=%_C% -p:SkipReferencesToPack=true -t:Pack src\wixext\WixToolset.Bal.wixext.csproj || exit /b
 msbuild -p:Configuration=%_C% -t:Pack src\WixToolset.Mba.Host\WixToolset.Mba.Host.csproj || exit /b
 
 @popd

--- a/src/WixToolset.Dnc.Host/WixToolset.Dnc.Host.csproj
+++ b/src/WixToolset.Dnc.Host/WixToolset.Dnc.Host.csproj
@@ -8,6 +8,7 @@
     <Description>WiX Toolset .NET Core BA Host</Description>
     <Title>WiX Toolset .NET Core BA Host</Title>
     <DebugType>embedded</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WixToolset.Mba.Host/WixToolset.Mba.Host.csproj
+++ b/src/WixToolset.Mba.Host/WixToolset.Mba.Host.csproj
@@ -9,6 +9,7 @@
     <Description>Managed Bootstrapper Application entry point</Description>
     <DebugType>embedded</DebugType>
     <NuspecFile>$(MSBuildThisFileName).nuspec</NuspecFile>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/wixext/WixToolset.Bal.wixext.csproj
+++ b/src/wixext/WixToolset.Bal.wixext.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\wixlib\bal.wixproj" ReferenceOutputAssembly="false" Condition=" '$(NCrunch)'=='' " />
+    <ProjectReference Include="..\wixlib\bal.wixproj" ReferenceOutputAssembly="false" Condition=" '$(NCrunch)'=='' and '$(SkipReferencesToPack)'!='true' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/wixext/WixToolset.Bal.wixext.nuspec
+++ b/src/wixext/WixToolset.Bal.wixext.nuspec
@@ -19,6 +19,8 @@
 
     <file src="netstandard2.0\$id$.dll" target="tools" />
 
-    <file src="Win32\*.pdb" target="pdbs\Win32" />
+    <file src="x86\*.pdb" target="pdbs\x86" />
+    <file src="x64\*.pdb" target="pdbs\x64" />
+    <file src="ARM64\*.pdb" target="pdbs\ARM64" />
   </files>
 </package>


### PR DESCRIPTION
Update WixToolset.Bal.wixext to where it shouldn't rebuild during packing so the tests were run on the shipped code.
Add 64-bit symbols and use x86 symbols to match the wixlib bind path.