### PR TITLE
Revert to using BaseBurnBackendBinderExtension::PostBackendBind

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "WixToolset.Sdk": "4.0.0-build-0190"
+    "WixToolset.Sdk": "4.0.0-build-0192"
   },
   "sdk": {
     "allowPrerelease": false

--- a/src/wixext/BalBurnBackendExtension.cs
+++ b/src/wixext/BalBurnBackendExtension.cs
@@ -11,7 +11,7 @@ namespace WixToolset.Bal
     using WixToolset.Data.Symbols;
     using WixToolset.Extensibility;
 
-    public class BalBurnBackendExtension : BaseBurnBackendExtension
+    public class BalBurnBackendExtension : BaseBurnBackendBinderExtension
     {
         private static readonly IntermediateSymbolDefinition[] BurnSymbolDefinitions =
         {
@@ -27,12 +27,9 @@ namespace WixToolset.Bal
 
         protected override IEnumerable<IntermediateSymbolDefinition> SymbolDefinitions => BurnSymbolDefinitions;
 
-        public override void BundleFinalize()
+        public override void SymbolsFinalized(IntermediateSection section)
         {
-            base.BundleFinalize();
-
-            var intermediate = this.Context.IntermediateRepresentation;
-            var section = intermediate.Sections.Single();
+            base.SymbolsFinalized(section);
 
             var baSymbol = section.Symbols.OfType<WixBootstrapperApplicationDllSymbol>().SingleOrDefault();
             var baId = baSymbol?.Id?.Id;


### PR DESCRIPTION
Since BundleFinalize has been removed from BaseBurnBackendBinderExtension it's necessary to revert to using BaseBurnBackendBinderExtension::PostBackendBind.